### PR TITLE
fix(security): replace insecure PRNG, harden JSON.parse, fix ESLint errors

### DIFF
--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -5,7 +5,7 @@ import { PredictModule } from '../modules/predict';
 /**
  * Options for creating a module
  */
-export interface ModuleOptions<TInput extends Record<string, any>, TOutput extends Record<string, any>> {
+export interface ModuleOptions<TInput extends Record<string, any>> {
   name: string;
   signature: Signature;
   promptTemplate: (input: TInput) => string;
@@ -15,14 +15,14 @@ export interface ModuleOptions<TInput extends Record<string, any>, TOutput exten
 /**
  * Factory function to create modules based on strategy
  */
-export function defineModule<TInput extends Record<string, any>, TOutput extends Record<string, any>>(
-  options: ModuleOptions<TInput, TOutput>
-): Module<TInput, TOutput> {
+export function defineModule<TInput extends Record<string, any>, TResult extends Record<string, any>>(
+  options: ModuleOptions<TInput>
+): Module<TInput, TResult> {
   const strategy = options.strategy || 'Predict';
 
   switch (strategy) {
     case 'Predict':
-      return new PredictModule<TInput, TOutput>(options);
+      return new PredictModule<TInput, TResult>(options);
     
     case 'ChainOfThought':
     case 'ReAct':

--- a/src/core/module.ts
+++ b/src/core/module.ts
@@ -1,4 +1,4 @@
-import { Signature, FieldDefinition } from './signature';
+import { Signature } from './signature';
 
 /**
  * Base class for DSPy.ts modules.

--- a/src/lm/onnx.ts
+++ b/src/lm/onnx.ts
@@ -107,7 +107,7 @@ export class ONNXModel implements LMDriver {
     // This will be expanded in future phases to handle actual tokenization
     this.tokenizer = {
       encode: (text: string) => new Float32Array([text.length]), // Dummy implementation
-      decode: (tokens: Float32Array) => 'Decoded text' // Dummy implementation
+      decode: (_tokens: Float32Array) => 'Decoded text' // Dummy implementation
     };
   }
 

--- a/src/lm/torch.ts
+++ b/src/lm/torch.ts
@@ -215,7 +215,7 @@ export class TorchModel implements LMDriver {
   /**
    * Process output tensor to text
    */
-  private processOutput(output: torch.Tensor, options?: GenerationOptions): string {
+  private processOutput(output: torch.Tensor, _options?: GenerationOptions): string {
     // For MVP, return a simple string based on the output tensor
     // This will be replaced with actual detokenization in future phases
     const shape = output.shape.join('x');

--- a/src/memory/agentdb/client.ts
+++ b/src/memory/agentdb/client.ts
@@ -8,6 +8,7 @@
  * environments without native deps.
  */
 
+import { randomBytes } from 'crypto';
 import pino from 'pino';
 import retry from 'async-retry';
 import { AgentDBConfig, mergeConfig } from './config';
@@ -461,7 +462,7 @@ export class AgentDBClient {
   }
 
   private generateId(): string {
-    return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+    return `${Date.now()}-${randomBytes(5).toString('hex')}`;
   }
 
   private invalidateCache(): void {

--- a/src/memory/reasoning-bank/bank.ts
+++ b/src/memory/reasoning-bank/bank.ts
@@ -4,9 +4,10 @@
  * Persistent memory system for AI agents with self-learning capabilities
  */
 
+import { randomBytes } from 'crypto';
 import pino from 'pino';
 import { AgentDBClient } from '../agentdb/client';
-import { SAFLA, DEFAULT_SAFLA_CONFIG } from './safla';
+import { SAFLA } from './safla';
 import {
   KnowledgeUnit,
   Experience,
@@ -513,7 +514,7 @@ export class ReasoningBank {
    * Generate unique ID
    */
   private generateId(): string {
-    return `ku-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    return `ku-${Date.now()}-${randomBytes(5).toString('hex')}`;
   }
 
   /**

--- a/src/modules/chain-of-thought.ts
+++ b/src/modules/chain-of-thought.ts
@@ -169,7 +169,7 @@ export class ChainOfThought<
    */
   private parseCoTResponse(response: string): Record<string, any> {
     // Try to extract JSON from response
-    let jsonMatch = response.match(/\{[\s\S]*\}/);
+    const jsonMatch = response.match(/\{[\s\S]*\}/);
 
     if (jsonMatch) {
       try {
@@ -181,7 +181,7 @@ export class ChainOfThought<
         }
 
         return parsed;
-      } catch (error) {
+      } catch {
         // JSON parsing failed, fallback
       }
     }

--- a/src/modules/react.ts
+++ b/src/modules/react.ts
@@ -422,7 +422,7 @@ export class ReAct<
    */
   private parseAnswer(
     answerText: string,
-    steps: ReActStep[]
+    _steps: ReActStep[]
   ): Record<string, any> {
     const result: Record<string, any> = {};
 
@@ -435,7 +435,7 @@ export class ReAct<
       const match = answerText.match(pattern);
 
       if (match) {
-        let value = match[1].trim().replace(/^["']|["']$/g, '');
+        const value = match[1].trim().replace(/^["']|["']$/g, '');
 
         // Type conversion
         if (field.type === 'number') {

--- a/src/optimize/bootstrap.ts
+++ b/src/optimize/bootstrap.ts
@@ -202,7 +202,12 @@ export class BootstrapFewShot<
 
   load(filePath: string): void {
     const safePath = safeResolvePath(filePath);
-    const data = JSON.parse(fs.readFileSync(safePath, 'utf8'));
+    let data: Record<string, any>;
+    try {
+      data = JSON.parse(fs.readFileSync(safePath, 'utf8'));
+    } catch (err) {
+      throw new Error(`Failed to parse saved state from ${safePath}: ${err instanceof Error ? err.message : String(err)}`);
+    }
     // Reconstructs with the fixed demo set (dynamic selection needs a live store, which isn't serialized).
     this.optimizedProgram = new BootstrapOptimizedModule(data.program.name, data.program.signature, data.program.demos ?? []);
     if (data.config) this.config = data.config;

--- a/src/optimize/gepa.ts
+++ b/src/optimize/gepa.ts
@@ -293,7 +293,12 @@ export class GEPA<TInput extends Record<string, any>, TOutput extends Record<str
 
   load(filePath: string): void {
     const safePath = safeResolvePath(filePath);
-    const data = JSON.parse(fs.readFileSync(safePath, 'utf8'));
+    let data: Record<string, any>;
+    try {
+      data = JSON.parse(fs.readFileSync(safePath, 'utf8'));
+    } catch (err) {
+      throw new Error(`Failed to parse saved state from ${safePath}: ${err instanceof Error ? err.message : String(err)}`);
+    }
     this.optimizedProgram = new OptimizedModule(data.program.name, data.program.signature, data.program.instruction, []);
     this.lastResult = data.result ?? null;
   }

--- a/src/optimize/miprov2.ts
+++ b/src/optimize/miprov2.ts
@@ -387,7 +387,12 @@ export class MIPROv2<TInput extends Record<string, any>, TOutput extends Record<
 
   load(filePath: string): void {
     const safePath = safeResolvePath(filePath);
-    const data = JSON.parse(fs.readFileSync(safePath, 'utf8'));
+    let data: Record<string, any>;
+    try {
+      data = JSON.parse(fs.readFileSync(safePath, 'utf8'));
+    } catch (err) {
+      throw new Error(`Failed to parse saved state from ${safePath}: ${err instanceof Error ? err.message : String(err)}`);
+    }
     this.optimizedProgram = new OptimizedModule(data.program.name, data.program.signature, data.program.instruction, data.program.demos ?? []);
     this.lastResult = data.result ?? null;
     if (data.config) this.config = data.config;

--- a/src/types/js-pytorch.d.ts
+++ b/src/types/js-pytorch.d.ts
@@ -21,18 +21,21 @@ declare module 'js-pytorch' {
   }
 
   interface Linear extends Module {
-    new(inputSize: number, outputSize: number): Linear;
     copy_: (value: any) => void;
   }
 
-  interface ReLU extends Module {
-    new(): ReLU;
+  interface LinearConstructor {
+    new(inputSize: number, outputSize: number): Linear;
+  }
+
+  interface ReLUConstructor {
+    new(): Module;
   }
 
   interface NN {
     Module: typeof Module;
-    Linear: Linear;
-    ReLU: ReLU;
+    Linear: LinearConstructor;
+    ReLU: ReLUConstructor;
   }
 
   // Mock support for testing


### PR DESCRIPTION
## Security Fixes

### CWE-338 — Insecure Pseudo-Random Number Generator

Two ID generators used `Math.random()` which is not cryptographically secure and produces predictable values that can be guessed by an attacker:

| File | Change |
|---|---|
| `src/memory/agentdb/client.ts` | `Math.random().toString(36)` → `crypto.randomBytes(5).toString('hex')` |
| `src/memory/reasoning-bank/bank.ts` | `Math.random().toString(36)` | → `crypto.randomBytes(5).toString('hex')` |

Both files now use Node.js `crypto.randomBytes` via a top-level `import { randomBytes } from 'crypto'`.

### Unguarded JSON.parse on file input

Three `load()` methods parsed file contents without error handling, meaning a malformed or corrupt saved-state file would throw an uncaught exception up the call stack with no context. Each now wraps `JSON.parse(readFileSync(...))` in a try/catch that re-throws with the file path and original message:

- `src/optimize/bootstrap.ts`
- `src/optimize/gepa.ts`
- `src/optimize/miprov2.ts`

## ESLint Error Fixes (11 → 0 errors)

| File | Rule | Fix |
|---|---|---|
| `src/core/factory.ts` | `no-unused-vars` | Remove phantom `TResult` from `ModuleOptions` interface (kept on function) |
| `src/core/module.ts` | `no-unused-vars` | Remove unused `FieldDefinition` import |
| `src/lm/onnx.ts` | `no-unused-vars` | Rename `tokens` → `_tokens` (intentionally unused param) |
| `src/lm/torch.ts` | `no-unused-vars` | Rename `options` → `_options` (intentionally unused param) |
| `src/modules/chain-of-thought.ts` | `prefer-const`, `no-unused-vars` | `let jsonMatch` → `const`; empty `catch` binding removed |
| `src/modules/react.ts` | `no-unused-vars`, `prefer-const` | `steps` → `_steps`; `let value` → `const value` |
| `src/types/js-pytorch.d.ts` | `no-misused-new` | Replace `new()` signatures on interfaces with proper `LinearConstructor`/`ReLUConstructor` interfaces |

## npm Audit

`npm audit` reported **0 vulnerabilities** before and after these changes. The `package.json` already contains `overrides` for `qs >= 6.15.0`, `protobufjs >= 7.5.8`, and `tar >= 7.5.11`.

## Test Plan

- [x] `npm audit` — 0 vulnerabilities
- [x] `npx tsc --noEmit` — clean (0 errors)
- [x] `npx eslint 'src/**/*.ts'` — 0 errors (147 pre-existing warnings, all `no-explicit-any` / missing return types)
- [x] `npm test` — 177/177 tests pass